### PR TITLE
fixed title bug

### DIFF
--- a/ClientSide/POD.ejs
+++ b/ClientSide/POD.ejs
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Connect With US</title>
+    <title>POD</title>
 </head>
 <link rel="stylesheet" href="/Styles/pod.css">
 <body>


### PR DESCRIPTION
Fixing the POD title issue, changing it from 'Connect with us' to 'POD'